### PR TITLE
changed the way internals are exposed.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -5074,11 +5074,11 @@ bool _event_loop_running = false;
 v8::Isolate* _isolate = nullptr;
 Environment* _environment = nullptr;
 
-namespace internal {
-  bool EventLoopIsRunning() {
-    return _event_loop_running;
-  }
+bool EventLoopIsRunning() {
+  return _event_loop_running;
+}
 
+namespace internal {
   v8::Isolate* isolate() {
     return _isolate;
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -5070,6 +5070,23 @@ Local<Context> context;
 Context::Scope* context_scope;
 bool request_stop = false;
 CmdArgs* cmd_args = nullptr;
+bool _event_loop_running = false;
+v8::Isolate* _isolate = nullptr;
+Environment* _environment = nullptr;
+
+namespace internal {
+  bool EventLoopIsRunning() {
+    return _event_loop_running;
+  }
+
+  v8::Isolate* isolate() {
+    return _isolate;
+  }
+
+  Environment* environment() {
+    return _environment;
+  }
+}
 
 namespace deinitialize {
 

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -9,17 +9,14 @@
 
 namespace node { namespace lib {
 
-    namespace { // private variables
-        bool _event_loop_running = false;
-        v8::Isolate* _isolate = nullptr;
-        Environment* _environment = nullptr;
+    namespace internal { // private variables
+
+        bool EventLoopIsRunning();
+
+        v8::Isolate* isolate();
+
+        Environment* environment();
     }
-
-    const bool EventLoopIsRunning() { return _event_loop_running; }
-
-    const v8::Isolate* isolate() { return _isolate; }
-
-    const Environment* environment() { return _environment; }
 
     /*********************************************************
      * Function types

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -9,14 +9,14 @@
 
 namespace node { namespace lib {
 
-    namespace internal { // private variables
-
-        bool EventLoopIsRunning();
+    namespace internal { // internals, made for experienced users
 
         v8::Isolate* isolate();
 
         Environment* environment();
     }
+
+    bool EventLoopIsRunning();
 
     /*********************************************************
      * Function types


### PR DESCRIPTION
This way is much cleaner, since the variables in the anonymous namespace are no longer there. Furthermore, the internals are no longer const, which enables the user to change them (this is required for almost all v8 methods).
Additionally, the internal getters are now within the `node::lib::internal` namespace, which indicates that the user has to know what shes doing. (we should provide some more documentation once the PR is merged)