### PR TITLE
Deinitialize Node.js properly

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -5144,7 +5144,9 @@ int _StopEnv() {
   delete context_scope;
   context_scope = nullptr;
 
-  delete &context;  // TOOD(js): correct way to delete this?
+  if (!context.IsEmpty()) {
+    context.Clear();
+  }
 
   delete isolate_data;
   isolate_data = nullptr;
@@ -5166,8 +5168,6 @@ void _DeleteIsolate() {
   CHECK_EQ(node_isolate, _isolate);
   node_isolate = nullptr;
   _isolate->Dispose();
-
-  delete &params;  // TODO(js): correct way to delete this?
 
   delete allocator;
   allocator = nullptr;

--- a/src/node.cc
+++ b/src/node.cc
@@ -5140,6 +5140,10 @@ int _StopEnv() {
   v8_platform.DrainVMTasks();
   WaitForInspectorDisconnect(_environment);
 
+  // TODO(th): delete env
+  // TODO(th): delete context scope
+  // TODO(th): delete context
+
   delete _handle_scope_wrapper;
   _handle_scope_wrapper = nullptr;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -5146,7 +5146,7 @@ int _StopEnv() {
   delete context_scope;
   context_scope = nullptr;
 
-  context->Dispose();
+  delete &context; // TOOD(js): correct way to delete this?
 
   delete isolate_data;
   isolate_data = nullptr;
@@ -5169,7 +5169,7 @@ void _DeleteIsolate() {
   node_isolate = nullptr;
   _isolate->Dispose();
 
-  params.Dispose();
+  delete &params; // TODO(js): correct way to delete this?
 
   delete allocator;
   allocator = nullptr;

--- a/src/node.cc
+++ b/src/node.cc
@@ -5070,7 +5070,7 @@ class CmdArgs {
 
 class HandleScopeHeapWrapper {
  public:
-  HandleScopeHeapWrapper(v8::Isolate* isolate)
+  explicit HandleScopeHeapWrapper(v8::Isolate* isolate)
     : scope_(isolate) { }
  private:
   HandleScope scope_;
@@ -5146,7 +5146,7 @@ int _StopEnv() {
   delete context_scope;
   context_scope = nullptr;
 
-  delete &context; // TOOD(js): correct way to delete this?
+  delete &context;  // TOOD(js): correct way to delete this?
 
   delete isolate_data;
   isolate_data = nullptr;
@@ -5169,7 +5169,7 @@ void _DeleteIsolate() {
   node_isolate = nullptr;
   _isolate->Dispose();
 
-  delete &params; // TODO(js): correct way to delete this?
+  delete &params;  // TODO(js): correct way to delete this?
 
   delete allocator;
   allocator = nullptr;

--- a/src/node.cc
+++ b/src/node.cc
@@ -5140,12 +5140,25 @@ int _StopEnv() {
   v8_platform.DrainVMTasks();
   WaitForInspectorDisconnect(_environment);
 
-  // TODO(th): delete env
-  // TODO(th): delete context scope
-  // TODO(th): delete context
+  delete _environment;
+  _environment = nullptr;
+
+  delete context_scope;
+  context_scope = nullptr;
+
+  context->Dispose();
+
+  delete isolate_data;
+  isolate_data = nullptr;
 
   delete _handle_scope_wrapper;
   _handle_scope_wrapper = nullptr;
+
+  delete isolate_scope;
+  isolate_scope = nullptr;
+
+  delete locker;
+  locker = nullptr;
 
   return exit_code;
 }
@@ -5155,6 +5168,11 @@ void _DeleteIsolate() {
   CHECK_EQ(node_isolate, _isolate);
   node_isolate = nullptr;
   _isolate->Dispose();
+
+  params.Dispose();
+
+  delete allocator;
+  allocator = nullptr;
 }
 
 void _DeinitV8() {
@@ -5354,6 +5372,8 @@ int Deinitialize() {
   deinitialize::_DeleteIsolate();
 
   deinitialize::_DeinitV8();
+
+  // TODO(js): do we need to tear down OpenSsl?
 
   deinitialize::_DeleteCmdArgs();
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -5145,6 +5145,7 @@ int _StopEnv() {
   context_scope = nullptr;
 
   if (!context.IsEmpty()) {
+    delete *context;
     context.Clear();
   }
 


### PR DESCRIPTION
**Original Node:** the HandleScope that contains all global objects was created on the stack in the Start() functions and destroyed when the scope of the Start() function was left

**Before in Node Lib:** the HandleScope was created as a static variable in the _CreateInitialEnvironment() function and destroyed only when the program exited

**Idea:** creating the HandleScope on the heap and delete it in Deinitialize()

**Problem:** HandleScopes can't be created on the heap

**Workaround in this PR:** adding a wrapper around the HandleScope, that can be created on the heap, and destroy this wrapper in Deinitialize()