### PR TITLE
allow optional REPL

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -197,17 +197,7 @@
         preloadModules();
         perf.markMilestone(
           NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END);
-        if (true) {
-          // TODO (cf): This should only happen if we run node via node::lib::Initialize().
-          //            It should not run if we call node::lib::Start().
-
-          // Do nothing. Calling evalScript is necessary however, because it sets
-          // globals.require to the require function.
-          // Otherwise, require doesn't work.
-          console.log('Embedded mode');
-          evalScript('[eval]');
-        // If -i or --interactive were passed, or stdin is a TTY.
-        } else if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
+        if (process._forceRepl || (process.allow_repl && NativeModule.require('tty').isatty(0))) {
           // REPL
           const cliRepl = NativeModule.require('internal/repl');
           cliRepl.createInternalRepl(process.env, function(err, repl) {
@@ -229,6 +219,9 @@
             // User passed '-e' or '--eval'
             evalScript('[eval]');
           }
+        } else if (!process.allow_repl && NativeModule.require('tty').isatty(0)) {
+          console.log('Embedded mode');
+          evalScript('[eval]');
         } else {
           // Read all of stdin - execute it.
           process.stdin.setEncoding('utf8');

--- a/src/node.cc
+++ b/src/node.cc
@@ -3786,7 +3786,7 @@ static void RawDebug(const FunctionCallbackInfo<Value>& args) {
   fflush(stderr);
 }
 
-void LoadEnvironment(Environment* env) {
+void LoadEnvironment(Environment* env, bool allow_repl) {
   HandleScope handle_scope(env->isolate());
 
   TryCatch try_catch(env->isolate());
@@ -3848,6 +3848,10 @@ void LoadEnvironment(Environment* env) {
   // who do not like how bootstrap_node.js sets up the module system but do
   // like Node's I/O bindings may want to replace 'f' with their own function.
   Local<Value> arg = env->process_object();
+  Local<Object> process_object = env->process_object();
+  process_object->Set(env->context(),
+                      String::NewFromUtf8(env->isolate(), "allow_repl"),
+                      Boolean::New(env->isolate(), allow_repl));
 
   auto ret = f->Call(env->context(), Null(env->isolate()), 1, &arg);
   // If there was an error during bootstrap then it was either handled by the
@@ -5070,7 +5074,8 @@ void _ConfigureOpenSsl() {
 }
 
 void _StartEnv(int argc,
-               const char* const* argv) {
+               const char* const* argv,
+               bool allow_repl) {
   std::cout << "Starting environment" << std::endl;
 
   int v8_argc = 0;
@@ -5095,7 +5100,7 @@ void _StartEnv(int argc,
   {
     Environment::AsyncCallbackScope callback_scope(_environment);
     _environment->async_hooks()->push_async_ids(1, 0);
-    LoadEnvironment(_environment);
+    LoadEnvironment(_environment, allow_repl);
     _environment->async_hooks()->pop_async_id(1);
   }
 
@@ -5105,12 +5110,13 @@ void _StartEnv(int argc,
 }  // namespace initialize
 
 void Initialize(const std::string& program_name,
-                const std::vector<std::string>& node_args) {
+                const std::vector<std::string>& node_args,
+                bool allow_repl) {
   cmd_args = new CmdArgs(program_name, node_args);
-  Initialize(cmd_args->argc, cmd_args->argv);
+  Initialize(cmd_args->argc, cmd_args->argv, allow_repl);
 }
 
-void Initialize(int argc, const char** argv) {
+void Initialize(int argc, const char** argv, bool allow_repl) {
   //////////
   // Start 1
   //////////
@@ -5146,7 +5152,7 @@ void Initialize(int argc, const char** argv) {
   // Start environment
   //////////
 
-  initialize::_StartEnv(argc, argv);
+  initialize::_StartEnv(argc, argv, allow_repl);
 }
 
 int Deinitialize() {
@@ -5369,7 +5375,7 @@ bool ProcessEvents(UvLoopBehavior behavior) {
 }
 
 int Start(int argc, char** argv) {
-  Initialize(argc, const_cast<const char**>(argv));
+  Initialize(argc, const_cast<const char**>(argv), true);
   RunEventLoop([] () {}, UvLoopBehavior::RUN_DEFAULT);
   return Deinitialize();
 }

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -80,9 +80,11 @@ bool eventLoopIsRunning();
  * not called.
  * @param program_name The name for the Node.js application.
  * @param node_args List of arguments for the Node.js engine.
+ * @param enable_stdin 
  */
 NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
-                            const std::vector<std::string>& node_args = {});
+                            const std::vector<std::string>& node_args = {},
+                            bool allow_repl = false);
 
 /**
  * @brief Starts the Node.js engine.
@@ -98,7 +100,9 @@ NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
  * where the first argument needs to be the program name.
  * The number of arguments must correspond to argc.
  */
-NODE_EXTERN void Initialize(int argc, const char** argv);
+NODE_EXTERN void Initialize(int argc,
+                            const char** argv,
+                            bool allow_repl = false);
 
 /**
  * @brief Stops the Node.js engine and destroys all current state.


### PR DESCRIPTION
gives us full control over REPL spawn when running in embedded mode
should provide full backwards compatibility.
old Start() behaviour is maintained, as REPL will only spawn when no js-file is provided upon call of Start()

fixes #34 