### PR TITLE
Replay "allow optional REPL" on new dev

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -195,7 +195,7 @@
         preloadModules();
         perf.markMilestone(
           NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END);
-        if (process._forceRepl || (process.allow_repl && NativeModule.require('tty').isatty(0))) {
+        if (process._forceRepl || (process._allowRepl && NativeModule.require('tty').isatty(0))) {
           // REPL
           const cliRepl = NativeModule.require('internal/repl');
           cliRepl.createInternalRepl(process.env, function(err, repl) {
@@ -218,7 +218,7 @@
             evalScript('[eval]');
           }
 
-        } else if (!process.allow_repl && NativeModule.require('tty').isatty(0)) {
+        } else if (!process._allowRepl && NativeModule.require('tty').isatty(0)) {
           console.log('Embedded mode');
           evalScript('[eval]');
         } else {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -195,7 +195,8 @@
         preloadModules();
         perf.markMilestone(
           NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END);
-        if (process._forceRepl || (process._allowRepl && NativeModule.require('tty').isatty(0))) {
+        if (process._forceRepl ||
+                (process._allowRepl && NativeModule.require('tty').isatty(0))) {
           // REPL
           const cliRepl = NativeModule.require('internal/repl');
           cliRepl.createInternalRepl(process.env, function(err, repl) {
@@ -218,9 +219,12 @@
             evalScript('[eval]');
           }
 
-        } else if (!process._allowRepl && NativeModule.require('tty').isatty(0)) {
-          console.log('Embedded mode');
-          evalScript('[eval]');
+        } else if (!process._allowRepl &&
+                   NativeModule.require('tty').isatty(0)) {
+          if (process._eval != null) {
+            // User passed '-e' or '--eval'
+            evalScript('[eval]');
+          }
         } else {
           // Read all of stdin - execute it.
           process.stdin.setEncoding('utf8');

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -195,17 +195,7 @@
         preloadModules();
         perf.markMilestone(
           NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END);
-        if (true) {
-          // TODO (cf): This should only happen if we run node via node::lib::Initialize().
-          //            It should not run if we call node::lib::Start().
-
-          // Do nothing. Calling evalScript is necessary however, because it sets
-          // globals.require to the require function.
-          // Otherwise, require doesn't work.
-          console.log('Embedded mode');
-          evalScript('[eval]');
-        // If -i or --interactive were passed, or stdin is a TTY.
-        } else if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
+        if (process._forceRepl || (process.allow_repl && NativeModule.require('tty').isatty(0))) {
           // REPL
           const cliRepl = NativeModule.require('internal/repl');
           cliRepl.createInternalRepl(process.env, function(err, repl) {
@@ -227,6 +217,10 @@
             // User passed '-e' or '--eval'
             evalScript('[eval]');
           }
+
+        } else if (!process.allow_repl && NativeModule.require('tty').isatty(0)) {
+          console.log('Embedded mode');
+          evalScript('[eval]');
         } else {
           // Read all of stdin - execute it.
           process.stdin.setEncoding('utf8');

--- a/src/node.cc
+++ b/src/node.cc
@@ -3351,7 +3351,7 @@ void LoadEnvironment(Environment* env, const bool allow_repl) {
                       Boolean::New(env->isolate(), allow_repl)).FromJust()) {
     env->async_hooks()->clear_async_id_stack();
     return;
-  };
+  }
 
   auto ret = f->Call(env->context(), Null(env->isolate()), 1, &arg);
   // If there was an error during bootstrap then it was either handled by the

--- a/src/node.cc
+++ b/src/node.cc
@@ -3343,7 +3343,7 @@ void LoadEnvironment(Environment* env, const bool allow_repl) {
   Local<Value> arg = env->process_object();
   Local<Object> process_object = env->process_object();
 
-  // add allow_repl parameter to JS process so we can use it in 
+  // add allow_repl parameter to JS process so we can use it in
   // bootstrap_node.js
   process_object->Set(env->context(),
                       String::NewFromUtf8(env->isolate(), "allow_repl"),

--- a/src/node.cc
+++ b/src/node.cc
@@ -3346,9 +3346,12 @@ void LoadEnvironment(Environment* env, const bool allow_repl) {
   // bootstrap_node.js.
   // If adding the parameter fails, bootstrapping will fail too,
   // so we can cleanup and return before we even bootstrap.
-  if (!Object::Cast(*arg)->Set(env->context(),
-                      String::NewFromUtf8(env->isolate(), "_allowRepl"),
-                      Boolean::New(env->isolate(), allow_repl)).FromJust()) {
+  bool successfully_set_allow_repl = Object::Cast(*arg)->Set(
+        env->context(),
+        String::NewFromUtf8(env->isolate(), "_allowRepl"),
+        Boolean::New(env->isolate(), allow_repl)).FromJust();
+
+  if (!successfully_set_allow_repl) {
     env->async_hooks()->clear_async_id_stack();
     return;
   }

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -80,9 +80,12 @@ bool eventLoopIsRunning();
  * not called.
  * @param program_name The name for the Node.js application.
  * @param node_args List of arguments for the Node.js engine.
+ * @param allow_repl Controls wether the node.js REPL gets spawned when no
+ * script is given on initialization.
  */
 NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
-                            const std::vector<std::string>& node_args = {});
+                            const std::vector<std::string>& node_args = {},
+                            const bool allow_repl = false);
 
 /**
  * @brief Starts the Node.js engine.
@@ -97,8 +100,10 @@ NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
  * @param argv List of arguments for the Node.js engine,
  * where the first argument needs to be the program name.
  * The number of arguments must correspond to argc.
+ * @param allow_repl Controls wether the node.js REPL gets spawned when no
+ * script is given on initialization.
  */
-NODE_EXTERN void Initialize(int argc, const char** argv);
+NODE_EXTERN void Initialize(int argc, const char** argv, const bool allow_repl = false);
 
 /**
  * @brief Stops the Node.js engine and destroys all current state.

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -80,8 +80,8 @@ bool eventLoopIsRunning();
  * not called.
  * @param program_name The name for the Node.js application.
  * @param node_args List of arguments for the Node.js engine.
- * @param allow_repl Controls wether the node.js REPL gets spawned when no
- * script is given on initialization.
+ * @param allow_repl Controls whether the node.js REPL gets spawned when stdin
+ * is an interactive terminal.
  */
 NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
                             const std::vector<std::string>& node_args = {},
@@ -100,8 +100,8 @@ NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
  * @param argv List of arguments for the Node.js engine,
  * where the first argument needs to be the program name.
  * The number of arguments must correspond to argc.
- * @param allow_repl Controls wether the node.js REPL gets spawned when no
- * script is given on initialization.
+ * @param allow_repl Controls whether the node.js REPL gets spawned when stdin
+ * is an interactive terminal.
  */
 NODE_EXTERN void Initialize(int argc,
                             const char** argv,

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -103,7 +103,9 @@ NODE_EXTERN void Initialize(const std::string& program_name = "node_lib",
  * @param allow_repl Controls wether the node.js REPL gets spawned when no
  * script is given on initialization.
  */
-NODE_EXTERN void Initialize(int argc, const char** argv, const bool allow_repl = false);
+NODE_EXTERN void Initialize(int argc,
+                            const char** argv,
+                            const bool allow_repl = false);
 
 /**
  * @brief Stops the Node.js engine and destroys all current state.


### PR DESCRIPTION
History can be found in PR #66.

gives us full control over REPL spawn when running in embedded mode
should provide full backwards compatibility.
old Start() behaviour is maintained, as REPL will only spawn when no js-file is provided upon call of Start()

fixes #34