### PR TITLE
Fix require not available in shared mode

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -221,10 +221,12 @@
 
         } else if (!process._allowRepl &&
                    NativeModule.require('tty').isatty(0)) {
-          if (process._eval != null) {
-            // User passed '-e' or '--eval'
-            evalScript('[eval]');
-          }
+          // We are on an interactive terminal but don't allow the REPL to
+          // start. This is the usual case if Node is used as a shared library.
+          // Calling evalScript is necessary however, because it sets
+          // globals.require to the require function.
+          // Otherwise, require doesn't work.
+          evalScript('[eval]');
         } else {
           // Read all of stdin - execute it.
           process.stdin.setEncoding('utf8');


### PR DESCRIPTION
This is a small fix that removes the if statement around `eval('[eval]')`.

@cmfcmf proposed to additionally replace allow_repl with startup_only, this is done in #75.