### PR TITLE
Remove initializer_list methods

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4834,12 +4834,6 @@ v8::MaybeLocal<v8::Value> Call(v8::Local<v8::Object> receiver,
                         const_cast<v8::Local<v8::Value>*>(&args[0]));
 }
 
-v8::MaybeLocal<v8::Value> Call(v8::Local<v8::Object> receiver,
-                               v8::Local<v8::Function> function,
-                               std::initializer_list<v8::Local<Value>> args) {
-  return Call(receiver, function, std::vector<v8::Local<v8::Value>>(args));
-}
-
 v8::MaybeLocal<v8::Value> Call(v8::Local<v8::Object> object,
                                const std::string& function_name,
                                const std::vector<v8::Local<v8::Value>>& args) {
@@ -4865,12 +4859,6 @@ v8::MaybeLocal<v8::Value> Call(v8::Local<v8::Object> object,
   }
 
   return Call(object, v8::Local<v8::Function>::Cast(value), args);
-}
-
-v8::MaybeLocal<v8::Value> Call(v8::Local<v8::Object> object,
-                               const std::string& function_name,
-                               std::initializer_list<v8::Local<Value>> args) {
-  return Call(object, function_name, std::vector<v8::Local<v8::Value>>(args));
 }
 
 v8::MaybeLocal<v8::Object> IncludeModule(const std::string& name) {

--- a/src/node_lib.h
+++ b/src/node_lib.h
@@ -282,23 +282,6 @@ NODE_EXTERN v8::MaybeLocal<v8::Value> Call(
     const std::vector<v8::Local<v8::Value>>& args = {});
 
 /**
- * @brief Calls a method on a given object.
- *
- * Calls a method on a given object.
- * The function is retrieved by using the functions name.
- * Additionally, a list of parameters is passed to the called function.
- * @param object The container of the called function.
- * @param function_name The name of the function to call.
- * @param args The parameters to pass to the called function. The amount of
- * arguments must be known at compile time.
- * @return The return value of the called function.
- */
-NODE_EXTERN v8::MaybeLocal<v8::Value> Call(
-    v8::Local<v8::Object> object,
-    const std::string& function_name,
-    std::initializer_list<v8::Local<v8::Value>> args);
-
-/**
  * @brief Calls a given method on a given object.
  *
  * Calls a given method on a given object.
@@ -312,22 +295,6 @@ NODE_EXTERN v8::MaybeLocal<v8::Value> Call(
     v8::Local<v8::Object> receiver,
     v8::Local<v8::Function> function,
     const std::vector<v8::Local<v8::Value>>& args = {});
-
-/**
- * @brief Calls a given method on a given object.
- *
- * Calls a given method on a given object.
- * Additionally, a list of parameters is passed to the called function.
- * @param object The receiver of the given function.
- * @param function The function to be called.
- * @param args The parameters to pass to the called function. The amount of
- * arguments must be known at compile time.
- * @return The return value of the called function.
- */
-NODE_EXTERN v8::MaybeLocal<v8::Value> Call(
-    v8::Local<v8::Object> receiver,
-    v8::Local<v8::Function> function,
-    std::initializer_list<v8::Local<v8::Value>> args);
 }  // namespace node
 
 


### PR DESCRIPTION
As discussed, removes the unneeded initializer_list methods from the interface.